### PR TITLE
Add frameNumber argument to allow specific frame rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lottie to SVG Converter
 
-> Convert the first frame of a [Lottie animation](https://github.com/airbnb/lottie-web) into an SVG. You may also be interested in the [Gatsby Remark plugin](https://github.com/chadly/gatsby-remark-lottie) that uses this project.
+> Convert a frame of a [Lottie animation](https://github.com/airbnb/lottie-web) into an SVG. You may also be interested in the [Gatsby Remark plugin](https://github.com/chadly/gatsby-remark-lottie) that uses this project.
 
 Convert this animation to a standard SVG:
 
@@ -12,9 +12,9 @@ This SVG is converted from [this animation](https://lottiefiles.com/28784-busine
 
 > Note that this README shows the animation as a GIF since I can't load the lottie scripts in a README.
 
-### Wait, just the first frame?
+### Wait, just one frame?
 
-Yes, just the first frame. This can be useful to show a preview of your animation as an SVG before the lottie animation script has fully loaded.
+Yes, just one frame. This can be useful to show a preview of your animation as an SVG before the lottie animation script has fully loaded.
 
 If you found this project because you wanted to convert your full lottie animation to an animated SVG, sorry, I can't help you. I would even go so far as to argue that you shouldn't want to do that. There is debate out there on whether CSS animations (which an animated SVG would use) is better/faster/stronger than JS animations. [JS animations win](https://greensock.com/css-performance). Keep using lottie. Be happy.
 
@@ -36,7 +36,7 @@ const renderSvg = require("lottie-to-svg");
 const animationData = JSON.parse(fs.readFileSync(`myanim.json`, "utf8"));
 
 renderSvg(animationData).then(svg => {
-	fs.writeFileSync(`myanim.svg`, svg, "utf8");
+  fs.writeFileSync(`myanim.svg`, svg, "utf8");
 });
 ```
 
@@ -44,8 +44,12 @@ renderSvg(animationData).then(svg => {
 
 You can pass render settings for [lottie-web](https://github.com/airbnb/lottie-web) (which does the actual rendering of the animation) as the second argument to `renderSvg`. See full list of [available options](https://github.com/airbnb/lottie-web#other-loading-options).
 
+### Frame Number
+
+You can pass a frame number (to render a specific frame) as the third argument to `renderSvg`. By default it will render the first frame.
+
 ## How It Works
 
 [lottie-web](https://github.com/airbnb/lottie-web) only supports rendering in a browser environment. This project uses [jsdom](https://github.com/jsdom/jsdom) to fool lottie-web into rendering in a node environment.
 
-It uses lottie's SVG renderer to render the first frame of the animation and then pulls the outputted SVG out of jsdom and then gives it to you, dear user, to do what you will with it.
+It uses lottie's SVG renderer to render one frame of the animation and then pulls the outputted SVG out of jsdom and then gives it to you, dear user, to do what you will with it.

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const { JSDOM } = require("jsdom");
 
-module.exports = async (animationData, opts) => {
+module.exports = async (animationData, opts, frameNumber) => {
 	const { window } = new JSDOM("<!DOCTYPE html><body></body>", {
 		pretendToBeVisual: true
 	});
@@ -15,6 +15,6 @@ module.exports = async (animationData, opts) => {
 	// load the lottie renderer late after globals are set
 	const renderToDom = require("./render");
 
-	const result = await renderToDom(document, animationData, opts || {});
+	const result = await renderToDom(document, animationData, opts || {}, frameNumber || 0);
 	return result;
 };

--- a/src/render.js
+++ b/src/render.js
@@ -1,6 +1,6 @@
 const lottie = require("lottie-web");
 
-module.exports = (document, animationData, opts) =>
+module.exports = (document, animationData, opts, frameNumber) =>
 	new Promise((resolve, reject) => {
 		try {
 			const container = document.createElement("div");
@@ -16,6 +16,7 @@ module.exports = (document, animationData, opts) =>
 			});
 
 			instance.addEventListener("DOMLoaded", () => {
+				instance.goToAndStop(frameNumber, true)
 				resolve(container.innerHTML);
 			});
 		} catch (err) {


### PR DESCRIPTION
Added the ability to render a specific `frameNumber` rather than always just rendering the first frame. 

My use case here: 
- I have a set of assets that are being generated from CMS defined list of lottie animations at build time
- I have an animation with segments, it plays an "enter" animation first, then loops using a later starting point. The very first frame is blank, as the enter animation hasn't yet played. 
- In some cases only the still SVG is displayed, like for users with `prefers-reduced-motion` enabled. I need to be able to display different still frame than the very first one, while still maintaining the nice dynamic generation 🚀 

Cheers!
